### PR TITLE
Add DESCRIBE TABLE SQL command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ The CLI provides an interactive shell to run SQL commands:
 
 Type `help` for a list of commands.
 
+> [!NOTE]
+> You can now run standard SQL introspection via `DESCRIBE table_name;` (or `DESC`) to view column metadata without leaving the
+> SQL workflow.
+
 > [!TIP]
 > Visit any `./latticedb` file in either `build` or `build-container` to see available options and run it so you don't have to manually build every time.
 

--- a/cli_main.cpp
+++ b/cli_main.cpp
@@ -155,6 +155,7 @@ private:
     std::cout << "  UPDATE                   Update data\n";
     std::cout << "  DELETE FROM              Delete data\n";
     std::cout << "  ALTER TABLE              Modify table structure\n";
+    std::cout << "  DESCRIBE [TABLE]         Show table schema\n";
     std::cout << "\n";
 
     // Examples

--- a/src/query/sql_parser.h
+++ b/src/query/sql_parser.h
@@ -20,7 +20,8 @@ enum class QueryType {
   DROP_INDEX,
   BEGIN,
   COMMIT,
-  ROLLBACK
+  ROLLBACK,
+  DESCRIBE_TABLE
 };
 
 enum class ExpressionType { CONSTANT, COLUMN_REF, OPERATOR, FUNCTION, STAR, AGGREGATE };
@@ -162,6 +163,10 @@ struct DropIndexQuery {
   bool if_exists = false;
 };
 
+struct DescribeTableQuery {
+  std::string table_name;
+};
+
 struct ParsedQuery {
   QueryType type;
   std::string error_message;
@@ -175,6 +180,7 @@ struct ParsedQuery {
   std::unique_ptr<DropTableQuery> drop_table;
   std::unique_ptr<CreateIndexQuery> create_index;
   std::unique_ptr<DropIndexQuery> drop_index;
+  std::unique_ptr<DescribeTableQuery> describe_table;
 
   ParsedQuery() : type(QueryType::INVALID) {}
 };
@@ -205,6 +211,7 @@ private:
   std::unique_ptr<DropTableQuery> parse_drop_table();
   std::unique_ptr<CreateIndexQuery> parse_create_index();
   std::unique_ptr<DropIndexQuery> parse_drop_index();
+  std::unique_ptr<DescribeTableQuery> parse_describe();
 
   std::unique_ptr<Expression> parse_expression();
   std::unique_ptr<Expression> parse_and_or();

--- a/src/types/value.cpp
+++ b/src/types/value.cpp
@@ -22,6 +22,44 @@ static bool is_numeric(ValueType t) {
   }
 }
 
+std::string value_type_to_string(ValueType type) {
+  switch (type) {
+  case ValueType::NULL_TYPE:
+    return "NULL";
+  case ValueType::BOOLEAN:
+    return "BOOLEAN";
+  case ValueType::TINYINT:
+    return "TINYINT";
+  case ValueType::SMALLINT:
+    return "SMALLINT";
+  case ValueType::INTEGER:
+    return "INTEGER";
+  case ValueType::BIGINT:
+    return "BIGINT";
+  case ValueType::DECIMAL:
+    return "DECIMAL";
+  case ValueType::REAL:
+    return "REAL";
+  case ValueType::DOUBLE:
+    return "DOUBLE";
+  case ValueType::VARCHAR:
+    return "VARCHAR";
+  case ValueType::TEXT:
+    return "TEXT";
+  case ValueType::TIMESTAMP:
+    return "TIMESTAMP";
+  case ValueType::DATE:
+    return "DATE";
+  case ValueType::TIME:
+    return "TIME";
+  case ValueType::BLOB:
+    return "BLOB";
+  case ValueType::VECTOR:
+    return "VECTOR";
+  }
+  return "UNKNOWN";
+}
+
 std::string Value::to_string() const {
   std::ostringstream ss;
   switch (type_) {

--- a/src/types/value.h
+++ b/src/types/value.h
@@ -28,6 +28,8 @@ enum class ValueType {
   VECTOR
 };
 
+std::string value_type_to_string(ValueType type);
+
 class Value {
 public:
   using ValueData = std::variant<std::monostate,       // NULL


### PR DESCRIPTION
## Summary
- add DESCRIBE/DESC parsing to the SQL engine and propagate describe queries through execution
- expose describe table metadata via the CLI help and documentation
- introduce a reusable ValueType-to-string helper for formatting schema descriptions

## Testing
- cmake --build build -j2

------
https://chatgpt.com/codex/tasks/task_e_68d719991930832ca84677dc3ac79054