### PR TITLE
Add CLI diagnostics reporting support

### DIFF
--- a/src/diagnostics/system_info.cpp
+++ b/src/diagnostics/system_info.cpp
@@ -256,6 +256,11 @@ std::string SystemDiagnostics::export_text_report() const {
   return ss.str();
 }
 
+void SystemDiagnostics::update_database_info(const DatabaseInfo& info) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  db_info_ = info;
+}
+
 void SystemDiagnostics::reset_metrics() {
   std::lock_guard<std::mutex> lock(mutex_);
   metrics_ = PerformanceMetrics();

--- a/src/diagnostics/system_info.h
+++ b/src/diagnostics/system_info.h
@@ -91,6 +91,9 @@ public:
   std::string export_json_report() const;
   std::string export_text_report() const;
 
+  // Update metadata
+  void update_database_info(const DatabaseInfo& info);
+
   // Reset statistics
   void reset_metrics();
 


### PR DESCRIPTION
## Summary
- add a `.diagnostics` meta command to the interactive shell for viewing or exporting system diagnostics reports
- record connections, query timings, and transaction outcomes so diagnostics metrics stay current
- expose an API to refresh database metadata in the diagnostics subsystem during engine initialization

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build latticedb_shell`


------
https://chatgpt.com/codex/tasks/task_e_68d74fe938bc832cbe57e0e838fa07a0